### PR TITLE
add links in readme & modify contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,17 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
    ```
    git checkout -b feature/your-feature-name
    ```
-5. Make your changes and ensure your code is clean and well-documented.
-6. Test your changes thoroughly.
-7. Commit your changes:
+4. Make your changes and ensure your code is clean and well-documented.
+5. Test your changes thoroughly.
+6. Commit your changes:
    ```
    git commit -m "Descriptive commit message"
    ```
-8. Push to your forked repository:
+7. Push to your forked repository:
    ```
    git push origin feature/your-feature-name
    ```
-9. Open a pull request on the main repository's branch with a valuable title and description.
+8. Open a pull request on the main repository's branch with a valuable title and description.
 
 
 ## Check if an issue exists

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,36 @@
 
 # Contributing Guidelines
 
-Welcome to the [Your Repository Name] repository! We're thrilled to have you here. 
+Welcome to the soniyaprasad77's portfolio repository! We're thrilled to have you here. 
+
+## Code of Conduct
+
+Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ## How to Contribute
 
 1. Fork the repository.
 2. Clone the forked repository to your local machine.
-3. Create a new branch for your contribution:
+3. Once you're assigned to an issue (see [check if an issue exists and other paragraphs below](#check-if-an-issue-exists)) create a new branch for your contribution:
    ```
    git checkout -b feature/your-feature-name
    ```
-4. Make your changes and ensure your code is clean and well-documented.
-5. Test your changes thoroughly.
-6. Commit your changes:
+5. Make your changes and ensure your code is clean and well-documented.
+6. Test your changes thoroughly.
+7. Commit your changes:
    ```
    git commit -m "Descriptive commit message"
    ```
-7. Push to your forked repository:
+8. Push to your forked repository:
    ```
    git push origin feature/your-feature-name
    ```
-8. Open a pull request on the main repository's branch.
+9. Open a pull request on the main repository's branch with a valuable title and description.
 
-## Code of Conduct
 
-Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+## Check if an issue exists
+
+If you spot a problem, please [search if an issue already exists](https://github.com/soniyaprasad77/soniyaprasad77.github.io/issues). If nobody is assigned to this issue, comment the issue to ask to be assigned by maintainers.
 
 ## Reporting Bugs
 
@@ -35,9 +40,9 @@ If you find a bug, please open an issue and provide detailed information about h
 
 If you have an idea for an enhancement, please open an issue and outline your proposal.
 
-## Style Guide
+<!-- ## Style Guide -->
 
-Please follow our [Style Guide](STYLE_GUIDE.md) to maintain a consistent codebase.
+<!-- Please follow our [Style Guide](STYLE_GUIDE.md) to maintain a consistent codebase. -->
 
 ## License
 
@@ -46,9 +51,3 @@ By contributing, you agree that your contributions will be licensed under the [L
 ## Acknowledgements
 
 We appreciate your time and effort in contributing to [https://github.com/soniyaprasad77/soniyaprasad77.github.io]!
-
----
-
-Remember to replace `[Your Repository Name]` with the actual name of your repository.
-
-Feel free to customize this template to better suit your specific needs and guidelines for contributions. You may want to include specific details about the technology stack, testing procedures, or any other specific requirements for contributors to follow.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ git clone https://github.com/YOUR_USERNAME/soniyaprasad77.github.io.git
 ```
 
 That's it, and you are ready to go!! 🎉
+
+## Contributing
+
+First of all, thank you for the time you'll take to contribute.  Every commit is valuable.
+
+For a pleasant adventure in open source contribution, please read the [code of conduct](./CODE_OF_CONDUCT.md) and the [contribution guide](./CONTRIBUTING.md).
+
+You'll find in these two files all informations you'll need.


### PR DESCRIPTION
## Pull Request

**Summary:**
Improved the ability to contribute by leading contributors to the guide

**Related Issue:**
Fix #4 

**Changes Made:**
I added a  "Contributing" paragraph in README linking to Contributing and code of conduct files.
I also changed some things in the Contributing file :
- replace the "[repo name]" that needed to be updated from the template used 😉 
- place Code of Conduct paragraph before the Contribution guidelines, seems to be the 1st thing to read before going deeper
- add a "check if issue exists" paragraph too 
- and add a line saying that someone needs to be assigned before coding (avoids working for something other one is working on, or any problems)

I also commented the style part as there is no style file for the moment, and removed the template part 😉 

**Screenshots (if applicable):**
I don't think so

**Additional Notes:**
Nope ;) 
