### PR TITLE
Added changes in style.css file in .about-col-1 img class

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -137,6 +137,7 @@ nav.scrolled {
 }
 .about-col-1 img {
   width: 100%;
+  margin-top: -100px;
   border-radius: 15px;
 }
 


### PR DESCRIPTION
## Pull Request

**Summary:**
The image in the about section is not properly aligned with the text, therefore, it looks unsymmetrical.

**Related Issue:**
#47 (Alignment of the profile picture)

**Changes Made:**
I have added a CSS property (margin-top: -100px) in the ".about-col-1 img" class in style.css file.

**Screenshots (if applicable):**

***BEFORE CHANGES***

![Screenshot (105)](https://github.com/soniyaprasad77/soniyaprasad77.github.io/assets/111532086/8da4b93b-7398-4836-bb7f-f5f3f17564f5)


***AFTER CHANGES***

![Screenshot (106)](https://github.com/soniyaprasad77/soniyaprasad77.github.io/assets/111532086/f528b85c-9437-4277-af94-8f8e30876bf4)





